### PR TITLE
Add Travis CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,15 +17,17 @@ before_script:
   - cd $TRAVIS_BUILD_DIR
   - wget http://git.savannah.gnu.org/cgit/lightning.git/snapshot/lightning-2.1.2.tar.gz
   - tar xzf lightning-2.1.2.tar.gz
-  - cd lightning-2.1.2 && autoreconf -i && ./configure --prefix=/home/travis/install
+  - cd lightning-2.1.2 && autoreconf -i && ./configure --prefix=$TRAVIS_BUILD_DIR/install
   - make && make install
-  # - cd ../libjit && ./bootstrap && ./configure --prefix=/home/travis/install
+  # - cd ../libjit && ./bootstrap && ./configure --prefix=$TRAVIS_BUILD_DIR/install
   # - make && make install
   # - find /home/travis/install
 
 script:
   - cd $TRAVIS_BUILD_DIR
+  - export LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/install/lib:$LD_LIBRARY_PATH
+  - export LIBRARY_PATH=$TRAVIS_BUILD_DIR/install/lib:$LIBRARY_PATH
   - make clean && make test JIT=sljit
   - ./test
-  - make clean && make test JIT=lightning LDFLAGS=-L/home/travis/install/lib CPPFLAGS=-I/home/travis/install/include
+  - make clean && make test JIT=lightning LDFLAGS="-L$TRAVIS_BUILD_DIR/install/lib -llightning" CPPFLAGS=-I$TRAVIS_BUILD_DIR/install/include
   - ./test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+dist: trusty
+sudo: false
+
+language: cpp
+
+compiler:
+  - gcc
+  - clang
+
+addons:
+  apt:
+    packages:
+    - texinfo
+
+before_script:
+  # - git clone --depth=1 https://git.savannah.gnu.org/git/libjit.git
+  - wget http://git.savannah.gnu.org/cgit/lightning.git/snapshot/lightning-2.1.2.tar.gz
+  - tar xzf lightning-2.1.2.tar.gz
+  - cd lightning-2.1.2 && autoreconf -i && ./configure --prefix=/home/travis/install
+  - make && make install
+  # - cd ../libjit && ./bootstrap && ./configure --prefix=/home/travis/install
+  # - make && make install
+  # - find /home/travis/install
+
+script:
+  - make clean && make JIT=sljit
+  - make clean && make JIT=lightning LDFLAGS=-L/home/travis/install/lib CPPFLAGS=/home/travis/install/include
+  # - make clean && make JIT=libjit LDFLAGS=-L/home/travis/install/lib CPPFLAGS=/home/travis/install/include

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ addons:
 
 before_script:
   # - git clone --depth=1 https://git.savannah.gnu.org/git/libjit.git
+  - cd $TRAVIS_BUILD_DIR
   - wget http://git.savannah.gnu.org/cgit/lightning.git/snapshot/lightning-2.1.2.tar.gz
   - tar xzf lightning-2.1.2.tar.gz
   - cd lightning-2.1.2 && autoreconf -i && ./configure --prefix=/home/travis/install
@@ -23,6 +24,8 @@ before_script:
   # - find /home/travis/install
 
 script:
-  - make clean && make JIT=sljit
-  - make clean && make JIT=lightning LDFLAGS=-L/home/travis/install/lib CPPFLAGS=/home/travis/install/include
-  # - make clean && make JIT=libjit LDFLAGS=-L/home/travis/install/lib CPPFLAGS=/home/travis/install/include
+  - cd $TRAVIS_BUILD_DIR
+  - make clean && make test JIT=sljit
+  - ./test
+  - make clean && make test JIT=lightning LDFLAGS=-L/home/travis/install/lib CPPFLAGS=-I/home/travis/install/include
+  - ./test

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ performance: performance.C $(OBJS)
 
 %.o : %.c
 	$(CC) $(CONFIG) -c $(CFLAGS) $(CPPFLAGS) $*.c -o $@
-	$(CC) $(CONFIG) -MM $(CXXFLAGS) $*.c > $*.d
+	$(CC) $(CONFIG) -MM $(CFLAGS) $*.c > $*.d
 
 clean:
 	rm -rf $(OBJS) *.o *.d mathparse performance

--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,13 @@ OBJS := SymbolicMathToken.o SymbolicMathTokenizer.o \
 include jit_$(JIT).mk
 
 mathparse: main.C $(OBJS)
-	$(CXX) -std=c++11 $(CONFIG) $(LDFLAGS) -o mathparse main.C $(OBJS)
+	$(CXX) -std=c++11 $(CONFIG)  $(CPPFLAGS) $(LDFLAGS) -o mathparse main.C $(OBJS)
 
 performance: performance.C $(OBJS)
-	$(CXX) -std=c++11 $(CONFIG) $(LDFLAGS) -o performance performance.C $(OBJS)
+	$(CXX) -std=c++11 $(CONFIG)  $(CPPFLAGS) $(LDFLAGS) -o performance performance.C $(OBJS)
+
+test: test.C $(OBJS)
+	$(CXX) -std=c++11 $(CONFIG)  $(CPPFLAGS) $(LDFLAGS) -o test test.C $(OBJS)
 
 -include $(OBJS:.o=.d)
 

--- a/Makefile
+++ b/Makefile
@@ -12,23 +12,23 @@ OBJS := SymbolicMathToken.o SymbolicMathTokenizer.o \
 include jit_$(JIT).mk
 
 mathparse: main.C $(OBJS)
-	$(CXX) -std=c++11 $(CONFIG)  $(CPPFLAGS) $(LDFLAGS) -o mathparse main.C $(OBJS)
+	$(CXX) -std=c++11 $(CONFIG)  $(CPPFLAGS) -o mathparse main.C $(OBJS) $(LDFLAGS)
 
 performance: performance.C $(OBJS)
-	$(CXX) -std=c++11 $(CONFIG)  $(CPPFLAGS) $(LDFLAGS) -o performance performance.C $(OBJS)
+	$(CXX) -std=c++11 $(CONFIG)  $(CPPFLAGS) -o performance performance.C $(OBJS) $(LDFLAGS)
 
 test: test.C $(OBJS)
-	$(CXX) -std=c++11 $(CONFIG)  $(CPPFLAGS) $(LDFLAGS) -o test test.C $(OBJS)
+	$(CXX) -std=c++11 $(CONFIG)  $(CPPFLAGS) -o test test.C $(OBJS) $(LDFLAGS)
 
 -include $(OBJS:.o=.d)
 
 %.o : %.C
 	$(CXX) -std=c++11 $(CONFIG) -c $(CXXFLAGS) $(CPPFLAGS) $*.C -o $@
-	$(CXX) -std=c++11 $(CONFIG) -MM $(CXXFLAGS) $*.C > $*.d
+	$(CXX) -std=c++11 $(CONFIG) -MM $(CXXFLAGS) $(CPPFLAGS) $*.C > $*.d
 
 %.o : %.c
 	$(CC) $(CONFIG) -c $(CFLAGS) $(CPPFLAGS) $*.c -o $@
-	$(CC) $(CONFIG) -MM $(CFLAGS) $*.c > $*.d
+	$(CC) $(CONFIG) -MM $(CFLAGS) $(CPPFLAGS) $*.c > $*.d
 
 clean:
 	rm -rf $(OBJS) *.o *.d mathparse performance

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SymbolicMath
+# SymbolicMath [![Build Status](https://travis-ci.org/dschwen/mathparse.svg?branch=master)](https://travis-ci.org/dschwen/mathparse)
 Abstract syntax tree (AST) based symbolic math system with an expression parser.
 
 It consists of
@@ -13,9 +13,9 @@ It consists of
 SymbolicMath features just-in-time (JIT) compilation of expression trees.
 Available JIT backends are
 
-* [GNU LibJIT](https://www.gnu.org/software/libjit/)
-* [SLJIT](http://sljit.sourceforge.net/) - Broad architecture support, no external dependencies
-* [GNU Lightning](https://www.gnu.org/software/lightning/) - Good architecture support
+* [GNU LibJIT](https://www.gnu.org/software/libjit/) - Fastest option, limited architecture support
+* [GNU Lightning](https://www.gnu.org/software/lightning/) - Good architecture support, medium speed
+* [SLJIT](http://sljit.sourceforge.net/) - Broad architecture support, no external dependencies, slowest option
 
 Research is ongoing as to which backend is best used.
 

--- a/SymbolicMathNodeDataLightning.C
+++ b/SymbolicMathNodeDataLightning.C
@@ -198,7 +198,7 @@ BinaryOperatorData::jit(JITStateValue & state)
       return;
 
     case BinaryOperatorType::EQUAL:
-      jit_ger_d(JIT_R0, JIT_F1, JIT_F0);
+      jit_eqr_d(JIT_R0, JIT_F1, JIT_F0);
       jit_extr_d(JIT_F0, JIT_R0);
       return;
 

--- a/jit_libjit.mk
+++ b/jit_libjit.mk
@@ -1,4 +1,4 @@
 # LibJIT
 OBJS += SymbolicMathFunctionLibJIT.o SymbolicMathNodeDataLibJIT.o
 CONFIG := -DSLJIT_CONFIG_AUTO=1 -DSYMBOLICMATH_USE_LIBJIT
-LDFLAGS += -ljit
+LDFLAGS := -ljit

--- a/jit_lightning.mk
+++ b/jit_lightning.mk
@@ -1,4 +1,4 @@
 # Lightning
 OBJS += SymbolicMathFunctionLightning.o SymbolicMathNodeDataLightning.o
 CONFIG := -DSYMBOLICMATH_USE_LIGHTNING
-LDFLAGS += -llightning
+LDFLAGS := -llightning

--- a/jit_sljit.mk
+++ b/jit_sljit.mk
@@ -2,4 +2,4 @@
 OBJS += contrib/sljit_src/sljitLir.o \
 				SymbolicMathFunctionSLJIT.o SymbolicMathNodeDataSLJIT.o
 CONFIG := -DSLJIT_CONFIG_AUTO=1 -DSYMBOLICMATH_USE_SLJIT
-LDFLAGS += contrib/sljit_src/sljitLir.c
+LDFLAGS := contrib/sljit_src/sljitLir.c

--- a/main.C
+++ b/main.C
@@ -61,7 +61,7 @@ main(int argc, char * argv[])
   deriv.compile();
 
   // evaluate for various values of c
-  for (c = -1.0; c <= 1.0; c += 0.3)
+  for (c = -1.0; c <= 1.0; c += 0.04)
     std::cout << deriv.value() << ' ';
   std::cout << '\n';
 

--- a/test.C
+++ b/test.C
@@ -1,0 +1,115 @@
+#include "SymbolicMath.h"
+#include "SymbolicMathFunction.h"
+#include "SymbolicMathHelpers.h"
+#include "SymbolicMathJITTypes.h"
+
+#include <iostream>
+
+struct Test
+{
+  std::string expression;
+  std::function<double(double)> native;
+};
+
+// clang-format off
+const std::vector<Test> tests = {
+  {"sin(c)", [](double c) { return std::sin(c); }},
+  {"cos(c)", [](double c) { return std::cos(c); }},
+  {"tan(c)", [](double c) { return std::tan(c); }},
+  {"erf(c)", [](double c) { return std::erf(c); }},
+  {"exp(c)", [](double c) { return std::exp(c); }},
+  {"pow(c,3)", [](double c) { return std::pow(c, 3); }},
+  {"pow(c,3.5)", [](double c) { return std::pow(c, 3.5); }},
+  {"pow(pow(c,3.5),2)", [](double c) { return std::pow(std::pow(c, 3.5), 2.0); }},
+  {"pow(pow(c,3.5),2.5)", [](double c) { return std::pow(std::pow(c, 3.5), 2.5); }},
+  {"pow(c,1)", [](double c) { return std::pow(c, 1); }},
+  {"c/1.0", [](double c) { return c / 1.0; }},
+  {"c+0", [](double c) { return c + 0.0; }},
+  {"c*0", [](double c) { return c * 0.0; }},
+  {"0/c", [](double c) { return 0.0 / c; }},
+  {"1 + c + 2*c + 3*c^3", [](double c) { return 1 + c + 2*c + 3*c*c*c; }},
+  {"c + sin(1.1)", [](double c) { return c + std::sin(1.1); }},
+  {"atan2(c,0.5)", [](double c) { return std::atan2(c, 0.5); }},
+  {"atan2(0.5,c)", [](double c) { return std::atan2(0.5, c); }},
+  {"atan2(2*c, 3*c)", [](double c) { return std::atan2(2*c, 3*c); }},
+  {"c<0.5 & c>-0.5", [](double c) { return c<0.5 && c>-0.5; }},
+  {"c>0.5 | c<-0.5", [](double c) { return c>0.5 || c<-0.5; }},
+};
+// clang-format off
+
+int
+main(int argc, char * argv[])
+{
+  double norm;
+  for (auto & test : tests)
+  {
+    SymbolicMath::Parser parser;
+
+    SymbolicMath::Real c;
+    auto c_var = std::make_shared<SymbolicMath::RealReferenceData>(c, "c");
+    parser.registerValueProvider(c_var);
+
+    auto func = parser.parse(test.expression);
+
+    // evaluate for various values of c
+    norm = 0.0;
+    for (c = -1.0; c <= 1.0; c += 0.3)
+      norm += std::abs(func.value() - test.native(c));
+    if (norm > 1e-9)
+    {
+      std::cerr << "Error evaluating unsimplified expression '" << test.expression << "'\n";
+      return 1;
+    }
+
+    func.simplify();
+
+    // evaluate for various values of c
+    norm = 0.0;
+    for (c = -1.0; c <= 1.0; c += 0.3)
+      norm += std::abs(func.value() - test.native(c));
+    if (norm > 1e-9)
+    {
+      std::cerr << "Error evaluating expression '" << test.expression << "' simplified to '" << func.format() << "'\n";
+      return 2;
+    }
+
+    func.compile();
+
+    // evaluate for various values of c
+    norm = 0.0;
+    for (c = -1.0; c <= 1.0; c += 0.3)
+      norm += std::abs(func.value() - test.native(c));
+    if (norm > 1e-9)
+    {
+      std::cerr << "Error evaluating compiled expression '" << test.expression << "' simplified to '" << func.format() << "'\n";
+      return 3;
+    }
+  }
+
+  // deriv.simplify();
+  //
+  // // evaluate for various values of c
+  // for (c = -1.0; c <= 1.0; c += 0.3)
+  //   std::cout << deriv.value() << ' ';
+  // std::cout << '\n';
+  //
+  // deriv.compile();
+  //
+  // // evaluate for various values of c
+  // for (c = -1.0; c <= 1.0; c += 0.3)
+  //   std::cout << deriv.value() << ' ';
+  //
+  // // finite differencing
+  // auto dc = 1.0e-9;
+  // for (c = -1.0; c <= 1.0; c += 0.3)
+  // {
+  //   auto a = func.value();
+  //   c += dc;
+  //   auto b = func.value();
+  //   c -= dc;
+  //   std::cout << (b - a) / dc << ' ';
+  // }
+  // std::cout << '\n';
+
+  return 0;
+}

--- a/test.C
+++ b/test.C
@@ -32,6 +32,12 @@ const std::vector<Test> tests = {
   {"atan2(c,0.5)", [](double c) { return std::atan2(c, 0.5); }},
   {"atan2(0.5,c)", [](double c) { return std::atan2(0.5, c); }},
   {"atan2(2*c, 3*c)", [](double c) { return std::atan2(2*c, 3*c); }},
+  {"c<0.2", [](double c) { return c<0.2; }},
+  {"c>0.2", [](double c) { return c>0.2; }},
+  {"c<=0.2", [](double c) { return c<=0.2; }},
+  {"c>=0.2", [](double c) { return c>=0.2; }},
+  {"c==0.2", [](double c) { return c==0.2; }},
+  {"c!=0.2", [](double c) { return c!=0.2; }},
   {"c<0.5 & c>-0.5", [](double c) { return c<0.5 && c>-0.5; }},
   {"c>0.5 | c<-0.5", [](double c) { return c>0.5 || c<-0.5; }},
 };

--- a/test.C
+++ b/test.C
@@ -40,6 +40,9 @@ const std::vector<Test> tests = {
   {"c!=0.2", [](double c) { return c!=0.2; }},
   {"c<0.5 & c>-0.5", [](double c) { return c<0.5 && c>-0.5; }},
   {"c>0.5 | c<-0.5", [](double c) { return c>0.5 || c<-0.5; }},
+  // currently failing:
+  // {"c<0.2 & 2.0", [](double c) { return c<0.2 && static_cast<bool>(2.0); }},
+  // {"c<0.2 | 2.0", [](double c) { return c<0.2 || static_cast<bool>(2.0); }},
 };
 // clang-format off
 


### PR DESCRIPTION
This adds a unit test executable and a Travis CI configuration. Currently this only works for SLJIT and lightning. LibJIT builds fail with a segmentation fault in the gen-apply helper executable.

I fixed the float comparisons in SLJIT. 
TODO: Fix and/or operators