### PR TITLE
Rebuild automatically when changing JIT backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,9 @@ script:
   - cd $TRAVIS_BUILD_DIR
   - export LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/install/lib:$LD_LIBRARY_PATH
   - export LIBRARY_PATH=$TRAVIS_BUILD_DIR/install/lib:$LIBRARY_PATH
-  - make clean && make test JIT=sljit
+  - make test JIT=sljit
   - ./test
-  - make clean && make test JIT=lightning LDFLAGS="-L$TRAVIS_BUILD_DIR/install/lib -llightning" CPPFLAGS=-I$TRAVIS_BUILD_DIR/install/include
+  - make test JIT=lightning LDFLAGS="-L$TRAVIS_BUILD_DIR/install/lib -llightning" CPPFLAGS=-I$TRAVIS_BUILD_DIR/install/include
   - ./test
-  - make clean && make test JIT=libjit LDFLAGS="-L$TRAVIS_BUILD_DIR/install/lib -ljit" CPPFLAGS=-I$TRAVIS_BUILD_DIR/install/include
+  - make test JIT=libjit LDFLAGS="-L$TRAVIS_BUILD_DIR/install/lib -ljit" CPPFLAGS=-I$TRAVIS_BUILD_DIR/install/include
   - ./test

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,15 @@ test: test.C $(OBJS)
 	$(CC) $(CONFIG) -c $(CFLAGS) $(CPPFLAGS) $*.c -o $@
 	$(CC) $(CONFIG) -MM $(CFLAGS) $(CPPFLAGS) $*.c > $*.d
 
+.PHONY: force clean
+.jit_backend: force
+	echo '$(JIT)' | cmp -s - $@ || echo '$(JIT)' > $@
+
+# force rebuild when compiling with a new JIT backend
+$(OBJS): .jit_backend
+
 clean:
-	rm -rf $(OBJS) *.o *.d mathparse performance
+	rm -rf $(OBJS) *.o *.d mathparse performance test2 test3
 
 tests: test2 test3
 


### PR DESCRIPTION
Removes the need to `make clean` before building with a new backend